### PR TITLE
Update nbviewer tutorial link to "stable" branch

### DIFF
--- a/app-qiskit.html
+++ b/app-qiskit.html
@@ -146,7 +146,7 @@
                 <p class="description">{{localize('learn_description')}}</p>
 
                 <p>
-                    <a target="_blank" href="https://nbviewer.jupyter.org/github/QISKit/qiskit-tutorial/blob/master/index.ipynb">
+                    <a target="_blank" href="https://nbviewer.jupyter.org/github/QISKit/qiskit-tutorial/blob/stable/index.ipynb">
                         <ibm-q-button secondary>{{localize('tutorials_button')}}</ibm-q-button>
                     </a>
                 </p>


### PR DESCRIPTION
Update the "Tutorials" link on the landing page to point to the `stable` branch of the tutorials, as since the latest changes on the `tutorials` repo, that is the branch that is meant to work with the streamlined, pip-installable version of `qiskit`